### PR TITLE
Add waveform resampling helper

### DIFF
--- a/src/pyPhyNR/core/waveform.py
+++ b/src/pyPhyNR/core/waveform.py
@@ -3,7 +3,6 @@ Waveform generation for 5G NR
 """
 
 import numpy as np
-from typing import Optional
 from .resources import ResourceGrid
 from .definitions import N_SC_PER_RB, N_SYMBOLS_PER_SLOT
 from .carrier import CarrierConfig
@@ -21,19 +20,33 @@ class WaveformGenerator:
         pass
 
     def _get_ofdm_params(self, carrier_config: CarrierConfig) -> OfdmParams:
+        """Calculate standard 3GPP OFDM parameters for this carrier.
+
+        The 3GPP-defined sampling rate is derived from the number of
+        configured resource blocks and numerology. If the user supplies a
+        different ``CarrierConfig.sample_rate`` the waveform will later be
+        resampled, but the OFDM parameters are always based on the standard
+        rate to preserve the requested sub-carrier spacing.
+
+        Args
+        ----
+        carrier_config: Carrier configuration
+
+        Returns
+        -------
+        OfdmParams
+            Calculated OFDM parameters using the standard sampling rate.
         """
-        Get OFDM parameters for the carrier configuration
-        
-        Args:
-            carrier_config: Carrier configuration
-            
-        Returns:
-            OfdmParams object with calculated parameters
-        """
+        scs_hz = carrier_config.subcarrier_spacing * 1000
+        n_subcarriers = carrier_config.n_resource_blocks * N_SC_PER_RB
+        # FFT size defined as next power-of-two >= occupied subcarriers
+        n_fft = 1 << (n_subcarriers - 1).bit_length()
+        standard_fs = scs_hz * n_fft
+
         return calculate_ofdm_params(
-            fs_hz=carrier_config.sample_rate,
+            fs_hz=standard_fs,
             mu=carrier_config.numerology.mu,
-            cp_type="normal"  # We can make this configurable later
+            cp_type="normal",  # We can make this configurable later
         )
 
     def generate_ofdm_symbol(self, data: np.ndarray, ofdm_params: OfdmParams, symbol_idx: int) -> np.ndarray:
@@ -107,7 +120,7 @@ class WaveformGenerator:
         Returns:
             IQ samples for the entire frame
         """
-        # Get OFDM parameters
+        # Get OFDM parameters at the 3GPP-defined sampling rate
         ofdm_params = self._get_ofdm_params(carrier_config)
 
         # Calculate total slots
@@ -122,7 +135,12 @@ class WaveformGenerator:
             frame_waveform.append(slot_waveform)
         
         waveform = np.concatenate(frame_waveform)
-        
+
+        # Resample if user-selected rate differs from standard rate
+        if abs(ofdm_params.fs - carrier_config.sample_rate) > 1:
+            from ..utils import resample_waveform
+            waveform = resample_waveform(waveform, ofdm_params.fs, carrier_config.sample_rate)
+
         return waveform
 
     def get_waveform_parameters(self, carrier_config: CarrierConfig) -> dict:
@@ -136,15 +154,22 @@ class WaveformGenerator:
             Dictionary with waveform parameters
         """
         ofdm_params = self._get_ofdm_params(carrier_config)
-        
+
         # Calculate total slots
         slots_per_subframe = carrier_config.numerology.slots_per_subframe
         total_slots = 10 * slots_per_subframe
         total_symbols = total_slots * N_SYMBOLS_PER_SLOT
-        
-        # Calculate total samples
+
+        # Calculate total samples at the standard rate
         samples_per_symbol = [ofdm_params.N_useful + cp for cp in ofdm_params.cp_per_symbol]
         total_samples = sum(samples_per_symbol) * total_slots
+
+        # Adjust sample count if resampling is needed
+        if abs(ofdm_params.fs - carrier_config.sample_rate) > 1:
+            total_samples = int(round(total_samples * carrier_config.sample_rate / ofdm_params.fs))
+            sample_rate = carrier_config.sample_rate
+        else:
+            sample_rate = ofdm_params.fs
 
         return {
             'fft_size': ofdm_params.N_fft,
@@ -157,7 +182,7 @@ class WaveformGenerator:
             'total_symbols': total_symbols,
             'total_samples': total_samples,
             'subcarrier_spacing': ofdm_params.scs_hz,
-            'sample_rate': ofdm_params.fs,
+            'sample_rate': sample_rate,
             'slot_duration': ofdm_params.slot_duration_s,
             'num_rb': carrier_config.n_resource_blocks,
             'numerology': ofdm_params.mu

--- a/src/pyPhyNR/utils/__init__.py
+++ b/src/pyPhyNR/utils/__init__.py
@@ -1,1 +1,9 @@
-from .plotting import plot_grid_dl, plot_grid_ul, plot_constellation, plot_time_domain, plot_frequency_domain
+from .plotting import (
+    plot_grid_dl,
+    plot_grid_ul,
+    plot_constellation,
+    plot_time_domain,
+    plot_frequency_domain,
+)
+from .resample import resample_waveform
+

--- a/src/pyPhyNR/utils/resample.py
+++ b/src/pyPhyNR/utils/resample.py
@@ -1,0 +1,27 @@
+import numpy as np
+from fractions import Fraction
+from scipy.signal import resample_poly
+
+
+def resample_waveform(iq: np.ndarray, fs_in: float, fs_out: float) -> np.ndarray:
+    """Resample complex waveform to a new sampling rate.
+
+    Parameters
+    ----------
+    iq : np.ndarray
+        Complex IQ samples at the original sampling rate.
+    fs_in : float
+        Original sampling rate in Hz.
+    fs_out : float
+        Desired sampling rate in Hz.
+
+    Returns
+    -------
+    np.ndarray
+        Resampled IQ array at ``fs_out``.
+    """
+    if fs_in == fs_out:
+        return iq
+
+    frac = Fraction(fs_out, fs_in).limit_denominator(1000)
+    return resample_poly(iq, frac.numerator, frac.denominator)


### PR DESCRIPTION
## Summary
- add `resample_waveform` utility using `scipy.signal.resample_poly`
- generate frames at standard OFDM rate and resample to user-selected rate when needed
- expose helper in utils and report sample counts after resampling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d0ab4e294832fab1c35da056c2a1f